### PR TITLE
Fix finish animation

### DIFF
--- a/Source/TransitionAnimator.swift
+++ b/Source/TransitionAnimator.swift
@@ -48,7 +48,9 @@ final class TransitionAnimator {
                 self.fromVC.view.removeFromSuperview()
             }
         } else {
-            self.toVC.view.removeFromSuperview()
+            if self.transitionType.isPresenting {
+                self.toVC.view.removeFromSuperview()
+            }
         }
         self.animation.finishAnimation(self.transitionType, didComplete: didComplete)
     }


### PR DESCRIPTION
I think when animation didn't finish on dismissing (which means it didn't close the screen) we should keep `self.toVC.view`.
For instance, I have a dialog with a background color alpha 50% that closes by dragging down.
It works fine when I drag and it reaches `panCompletionThreshold` but when it doesn't and the dialog goes back to its normal state the view behind suddenly disappears.
This should fix it. ;)
