### PR TITLE
Add panBoundsPoint property to TransitionGestureHandler

### DIFF
--- a/Source/TransitionGestureHandler.swift
+++ b/Source/TransitionGestureHandler.swift
@@ -32,6 +32,7 @@ public final class TransitionGestureHandler : NSObject {
     
     public var panStartThreshold: CGFloat = 10.0
     public var panCompletionThreshold: CGFloat = 30.0
+    public var panBoundsPoint: CGPoint?
     
     fileprivate(set) var isTransitioning: Bool = false
     fileprivate(set) var percentComplete: CGFloat = 0.0
@@ -120,16 +121,31 @@ public final class TransitionGestureHandler : NSObject {
     }
     
     fileprivate func updatePercentComplete(_ location: CGPoint) {
-        let bounds = self.targetVC.view.bounds
+        var bounds = CGFloat(0)
+        if let boundsPoint = panBoundsPoint {
+            switch self.direction {
+            case .top, .bottom:
+                bounds = abs(boundsPoint.y - panLocationStart)
+            case .left, .right:
+                bounds = abs(boundsPoint.x - panLocationStart)
+            }
+        } else {
+            switch self.direction {
+            case .top, .bottom:
+                bounds = self.targetVC.view.bounds.height
+            case .left, .right:
+                bounds = self.targetVC.view.bounds.width
+            }
+        }
         switch self.direction {
         case .top:
-            self.percentComplete = (self.panLocationStart - location.y) / bounds.height
+            self.percentComplete = min((self.panLocationStart - location.y) / bounds, 1)
         case .bottom:
-            self.percentComplete = (location.y - self.panLocationStart) / bounds.height
+            self.percentComplete = min((location.y - self.panLocationStart) / bounds, 1)
         case .left:
-            self.percentComplete = (self.panLocationStart - location.x) / bounds.width
+            self.percentComplete = min((self.panLocationStart - location.x) / bounds, 1)
         case .right:
-            self.percentComplete = (location.x - self.panLocationStart) / bounds.width
+            self.percentComplete = min((location.x - self.panLocationStart) / bounds, 1)
         }
     }
     


### PR DESCRIPTION
I was looking for a way to configure an end point to the pan gesture so the interactive transition would look smoother.

Imagine that you have a `targetView` that its position starts at the bottom of the screen with a pan gesture handler configured with `top` direction and ends at the center of the screen when transitioning to the next `viewController`. In current implementation the user would need to pan until the top of the screen and the `targetView` would look misplaced compared to the user's finger.

This PR fixes that by introducing a new`CGPoint` property to `TransitionGestureHandler` called `panBoundsPoint`.
When `panBoundsPoint` is set the `percentComplete` will take into account the `panBoundsPoint` as the endPoint of the transition instead of the `targetVC.view.bounds`.

To be honest I'm happy with the results but it seems that there's a best way to handle this.
Anyway it was the solution I came up with now.

Let me know what you think.