### PR TITLE
Fixed gesture handler state

### DIFF
--- a/Source/InteractiveTransitioning.swift
+++ b/Source/InteractiveTransitioning.swift
@@ -79,6 +79,7 @@ extension InteractiveTransitioning {
         let d = self.transitionDuration - (self.transitionDuration * abs(self.gestureHandler.percentComplete))
         
         self.animator.animate(TimeInterval(d), animations: { [weak self] in self?.animator.updateAnimation(1.0) }) { [weak self] finished in
+            self?.gestureHandler.finish()
             self?.animator.finishAnimation(true)
             self?.completeTransition(true)
         }
@@ -90,6 +91,7 @@ extension InteractiveTransitioning {
         let d = self.transitionDuration * abs(self.gestureHandler.percentComplete)
         
         self.animator.animate(TimeInterval(d), animations: { [weak self] in self?.animator.updateAnimation(0.0) }) { [weak self] finished in
+            self?.gestureHandler.finish()
             self?.animator.finishAnimation(false)
             self?.completeTransition(false)
         }

--- a/Source/TransitionGestureHandler.swift
+++ b/Source/TransitionGestureHandler.swift
@@ -132,10 +132,9 @@ public final class TransitionGestureHandler : NSObject {
             } else {
                 self.updateGestureHandler?(.cancel)
             }
-        case .cancelled:
-            if !self.isTransitioning { return }
-            self.updateGestureHandler?(.cancel)
-        default:
+        case .cancelled,
+             .failed,
+             .possible:
             if !self.isTransitioning { return }
             self.updateGestureHandler?(.cancel)
         }
@@ -229,6 +228,10 @@ public final class TransitionGestureHandler : NSObject {
         self.updateGestureHandler?(.start)
         self.setPanStartPoint(location)
         self.updatePercentComplete(location)
+    }
+
+    func finish() {
+        isTransitioning = false
     }
 }
 


### PR DESCRIPTION
After a cancelled interactive transaction the flag `isTransitioning` would remain `true`.
This was causing issues since the next transactions would still consider that flag.

You can simulate the issue in the music player example:
- Tap on the mini player (to open the fullscreen player)
- Drag the screen just a little bit from the top to start the transition but not enough to close it
- Then tap on the Close button

It won't close the screen since the transition is being handled by `InteractiveTransitioning` because `isTransitioning` is `true`.

I've added a new function in `TransitionGestureHandler` called `finish` that is called when the interactive transition is finished or cancelled.
This function is internal since I don't see any reason why someone would use it outside of the framework.